### PR TITLE
fix: show error message when non-file GitHub URL is pasted

### DIFF
--- a/components/FileSelector.test.tsx
+++ b/components/FileSelector.test.tsx
@@ -127,6 +127,35 @@ describe("FileSelector", () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ path: "README.md" }));
   });
 
+  test("shows error message when non-file GitHub URL is pasted", async () => {
+    render(<FileSelector side="left" value={defaultValue} onChange={() => {}} />);
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText(ownerRepoPlaceholder), {
+        target: { value: "https://github.com/ot-nemoto/github-diff/actions/runs/12345" },
+      });
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "ファイルの URL を入力してください",
+    );
+  });
+
+  test("clears error message when valid file URL is pasted after invalid URL", async () => {
+    const onChange = vi.fn();
+    render(<FileSelector side="left" value={defaultValue} onChange={onChange} />);
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText(ownerRepoPlaceholder), {
+        target: { value: "https://github.com/ot-nemoto/github-diff/actions/runs/12345" },
+      });
+    });
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText(ownerRepoPlaceholder), {
+        target: { value: "https://github.com/octocat/Hello-World/blob/main/README.md" },
+      });
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   test("calls onChange with updated ref", () => {
     const onChange = vi.fn();
     render(<FileSelector side="left" value={defaultValue} onChange={onChange} />);

--- a/components/FileSelector.test.tsx
+++ b/components/FileSelector.test.tsx
@@ -134,9 +134,7 @@ describe("FileSelector", () => {
         target: { value: "https://github.com/ot-nemoto/github-diff/actions/runs/12345" },
       });
     });
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "ファイルの URL を入力してください",
-    );
+    expect(screen.getByRole("alert")).toHaveTextContent("ファイルの URL を入力してください");
   });
 
   test("clears error message when valid file URL is pasted after invalid URL", async () => {

--- a/components/FileSelector.tsx
+++ b/components/FileSelector.tsx
@@ -55,14 +55,24 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
   });
   const [refsOwnerRepo, setRefsOwnerRepo] = useState("");
   const [files, setFiles] = useState<string[]>([]);
+  const [urlError, setUrlError] = useState("");
 
   const update = (field: keyof FileSpec, val: string) => {
     onChange({ ...value, [field]: val });
   };
 
+  const isGitHubUrl = (raw: string) => {
+    try {
+      return new URL(raw).hostname === "github.com";
+    } catch {
+      return false;
+    }
+  };
+
   const handleOwnerRepoChange = async (raw: string) => {
     const base = parseGitHubUrlBase(raw);
     if (base) {
+      setUrlError("");
       setOwnerRepo(`${base.owner}/${base.repo}`);
       const token = getToken() ?? undefined;
       const key = `${base.owner}/${base.repo}`;
@@ -74,6 +84,11 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
       onChange({ owner: base.owner, repo: base.repo, ref, path });
       return;
     }
+    if (isGitHubUrl(raw)) {
+      setUrlError("ファイルの URL を入力してください（例: .../blob/main/README.md）");
+      return;
+    }
+    setUrlError("");
     setOwnerRepo(raw);
     const idx = raw.indexOf("/");
     if (idx === -1) {
@@ -115,6 +130,7 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
           onChange={(e) => handleOwnerRepoChange(e.target.value)}
           onBlur={handleOwnerRepoBlur}
         />
+        {urlError && <p className="mt-1 text-xs text-red-600">{urlError}</p>}
       </div>
       <div>
         <label htmlFor={`${side}-ref`} className="block text-xs text-gray-500 mb-1">

--- a/components/FileSelector.tsx
+++ b/components/FileSelector.tsx
@@ -86,6 +86,7 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
       return;
     }
     if (isUrl(raw)) {
+      setOwnerRepo(raw);
       setUrlError("ファイルの URL を入力してください（例: .../blob/main/README.md）");
       return;
     }

--- a/components/FileSelector.tsx
+++ b/components/FileSelector.tsx
@@ -61,9 +61,10 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
     onChange({ ...value, [field]: val });
   };
 
-  const isGitHubUrl = (raw: string) => {
+  const isUrl = (raw: string) => {
     try {
-      return new URL(raw).hostname === "github.com";
+      const { protocol } = new URL(raw);
+      return protocol === "http:" || protocol === "https:";
     } catch {
       return false;
     }
@@ -84,7 +85,7 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
       onChange({ owner: base.owner, repo: base.repo, ref, path });
       return;
     }
-    if (isGitHubUrl(raw)) {
+    if (isUrl(raw)) {
       setUrlError("ファイルの URL を入力してください（例: .../blob/main/README.md）");
       return;
     }

--- a/components/FileSelector.tsx
+++ b/components/FileSelector.tsx
@@ -129,10 +129,16 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
           value={ownerRepo}
           placeholder="owner/repository または GitHub URL"
           className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          aria-invalid={!!urlError}
+          aria-describedby={urlError ? `${side}-url-error` : undefined}
           onChange={(e) => handleOwnerRepoChange(e.target.value)}
           onBlur={handleOwnerRepoBlur}
         />
-        {urlError && <p className="mt-1 text-xs text-red-600">{urlError}</p>}
+        {urlError && (
+          <p id={`${side}-url-error`} role="alert" className="mt-1 text-xs text-red-600">
+            {urlError}
+          </p>
+        )}
       </div>
       <div>
         <label htmlFor={`${side}-ref`} className="block text-xs text-gray-500 mb-1">

--- a/components/FileSelector.tsx
+++ b/components/FileSelector.tsx
@@ -61,10 +61,10 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
     onChange({ ...value, [field]: val });
   };
 
-  const isUrl = (raw: string) => {
+  const isGitHubUrl = (raw: string) => {
     try {
-      const { protocol } = new URL(raw);
-      return protocol === "http:" || protocol === "https:";
+      const { protocol, hostname } = new URL(raw);
+      return (protocol === "http:" || protocol === "https:") && hostname === "github.com";
     } catch {
       return false;
     }
@@ -85,7 +85,7 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
       onChange({ owner: base.owner, repo: base.repo, ref, path });
       return;
     }
-    if (isUrl(raw)) {
+    if (isGitHubUrl(raw)) {
       setOwnerRepo(raw);
       setUrlError("ファイルの URL を入力してください（例: .../blob/main/README.md）");
       return;


### PR DESCRIPTION
## Summary

- GitHub Actions や Issues など、ファイル URL でない GitHub URL を貼り付けた際にエラーメッセージを表示するよう修正
- 対象: `github.com` のホスト名を持つ URL で `/blob/`・`/blame/`・`/raw/` を含まない場合
- 表示メッセージ: `ファイルの URL を入力してください（例: .../blob/main/README.md）`

## Test plan

- [ ] CI のテスト・lint が通ること
- [ ] GitHub Actions の URL を貼り付けるとエラーメッセージが表示されること
- [ ] 有効なファイル URL を貼り付けるとエラーが消えて補完されること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)