### PR TITLE
[T14] リポジトリ名を github-diff-viewer に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # GitHub Diff
 
-![CI](https://github.com/ot-nemoto/github-diff/actions/workflows/ci.yml/badge.svg)
-![Version](https://img.shields.io/github/package-json/v/ot-nemoto/github-diff)
-![Next.js](https://img.shields.io/github/package-json/dependency-version/ot-nemoto/github-diff/next?logo=next.js&label=Next.js&color=black)
-![TypeScript](https://img.shields.io/github/package-json/dependency-version/ot-nemoto/github-diff/dev/typescript?logo=typescript&logoColor=white&label=TypeScript&color=3178C6)
-![Tailwind CSS](https://img.shields.io/github/package-json/dependency-version/ot-nemoto/github-diff/dev/tailwindcss?logo=tailwindcss&logoColor=white&label=Tailwind%20CSS&color=06B6D4)
-![License](https://img.shields.io/github/license/ot-nemoto/github-diff)
+![CI](https://github.com/ot-nemoto/github-diff-viewer/actions/workflows/ci.yml/badge.svg)
+![Version](https://img.shields.io/github/package-json/v/ot-nemoto/github-diff-viewer)
+![Next.js](https://img.shields.io/github/package-json/dependency-version/ot-nemoto/github-diff-viewer/next?logo=next.js&label=Next.js&color=black)
+![TypeScript](https://img.shields.io/github/package-json/dependency-version/ot-nemoto/github-diff-viewer/dev/typescript?logo=typescript&logoColor=white&label=TypeScript&color=3178C6)
+![Tailwind CSS](https://img.shields.io/github/package-json/dependency-version/ot-nemoto/github-diff-viewer/dev/tailwindcss?logo=tailwindcss&logoColor=white&label=Tailwind%20CSS&color=06B6D4)
+![License](https://img.shields.io/github/license/ot-nemoto/github-diff-viewer)
 
 異なる GitHub リポジトリ間でファイルを自由に比較できる Web ツール。
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Diff
+# GitHub Diff Viewer
 
 ![CI](https://github.com/ot-nemoto/github-diff-viewer/actions/workflows/ci.yml/badge.svg)
 ![Version](https://img.shields.io/github/package-json/v/ot-nemoto/github-diff-viewer)

--- a/components/FileSelector.test.tsx
+++ b/components/FileSelector.test.tsx
@@ -131,7 +131,7 @@ describe("FileSelector", () => {
     render(<FileSelector side="left" value={defaultValue} onChange={() => {}} />);
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText(ownerRepoPlaceholder), {
-        target: { value: "https://github.com/ot-nemoto/github-diff/actions/runs/12345" },
+        target: { value: "https://github.com/ot-nemoto/github-diff-viewer/actions/runs/12345" },
       });
     });
     expect(screen.getByRole("alert")).toHaveTextContent("ファイルの URL を入力してください");
@@ -142,7 +142,7 @@ describe("FileSelector", () => {
     render(<FileSelector side="left" value={defaultValue} onChange={onChange} />);
     await act(async () => {
       fireEvent.change(screen.getByPlaceholderText(ownerRepoPlaceholder), {
-        target: { value: "https://github.com/ot-nemoto/github-diff/actions/runs/12345" },
+        target: { value: "https://github.com/ot-nemoto/github-diff-viewer/actions/runs/12345" },
       });
     });
     expect(screen.getByRole("alert")).toBeInTheDocument();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,8 +75,8 @@ const isStatic = process.env.BUILD_MODE === "static";
 const nextConfig = {
   ...(isStatic && {
     output: "export",
-    basePath: "/github-diff",
-    assetPrefix: "/github-diff",
+    basePath: "/github-diff-viewer",
+    assetPrefix: "/github-diff-viewer",
     trailingSlash: true,
     images: { unoptimized: true },
   }),

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,8 +3,8 @@
 ## ローカルセットアップ
 
 ```bash
-git clone https://github.com/<owner>/github-diff.git
-cd github-diff
+git clone https://github.com/<owner>/github-diff-viewer.git
+cd github-diff-viewer
 npm install
 npm run dev
 ```

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,8 +5,8 @@ const isStatic = process.env.BUILD_MODE === "static";
 const nextConfig: NextConfig = {
   ...(isStatic && {
     output: "export",
-    basePath: "/github-diff",
-    assetPrefix: "/github-diff",
+    basePath: "/github-diff-viewer",
+    assetPrefix: "/github-diff-viewer",
     trailingSlash: true,
     images: { unoptimized: true },
   }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "github-diff",
+  "name": "github-diff-viewer",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "github-diff",
+      "name": "github-diff-viewer",
       "version": "0.2.0",
       "dependencies": {
         "@octokit/rest": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-diff",
+  "name": "github-diff-viewer",
   "version": "0.2.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## 概要

リポジトリ名変更（`github-diff` → `github-diff-viewer`）に伴うコード内参照の更新。

## 変更内容

| ファイル | 変更内容 |
|----------|----------|
| `next.config.ts` | `basePath` / `assetPrefix` を `/github-diff-viewer` に更新 |
| `package.json` | `name` を `github-diff-viewer` に更新 |
| `README.md` | バッジ URL（6箇所）を `ot-nemoto/github-diff-viewer` に更新 |
| `docs/architecture.md` | サンプルコードの `basePath` / `assetPrefix` を更新 |

## マージ後の作業（ユーザー）

1. GitHub Settings でリポジトリ名を `github-diff-viewer` に変更
2. ローカルのリモート URL を更新：
   ```bash
   git remote set-url origin https://github.com/ot-nemoto/github-diff-viewer.git
   ```

## 関連 Issue

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)