### PR TITLE
[T16] GitHub Actions の Node.js 20 非推奨警告を解消

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build:static
 
       - name: Upload static artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

- `actions/upload-pages-artifact@v3` → `@v5` にアップグレード
- `actions/deploy-pages@v4` → `@v5` にアップグレード

## 背景

Node.js 20 ベースのアクションが非推奨となり、2026年6月2日以降は Node.js 24 がデフォルトになる。対応しないと Actions が動作しなくなる可能性がある。

## Test plan

- [ ] CI が通ること
- [ ] Deploy to GitHub Pages ワークフローが正常に完了し、Annotation が解消されること

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)