### PR TITLE
[T18] UI リデザイン（GitHub 風ダークヘッダー・カードレイアウト）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { useQueryParams } from "@/hooks/useQueryParams";
 function ComparePageContent() {
   const { state, update } = useQueryParams();
   const [localState, setLocalState] = useState(state);
+  const [mode, setMode] = useState<"split" | "unified">("split");
   const leftFile = useFileContent();
   const rightFile = useFileContent();
   const initialFetchDone = useRef(false);
@@ -20,6 +21,8 @@ function ComparePageContent() {
   const isReady = (s: typeof localState.left) =>
     s.owner.trim() !== "" && s.repo.trim() !== "" && s.ref.trim() !== "" && s.path.trim() !== "";
   const canCompare = !isLoading && isReady(localState.left) && isReady(localState.right);
+
+  const fileName = localState.left.path.split("/").pop() ?? "";
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally run once on mount
   useEffect(() => {
@@ -35,19 +38,31 @@ function ComparePageContent() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white border-b border-gray-200 px-6 py-3 flex items-center justify-between">
-        <h1 className="text-lg font-semibold text-gray-900">GitHub Diff Viewer</h1>
+    <div className="min-h-screen bg-[#f6f8fa]">
+      <header className="h-12 bg-[#24292f] flex items-center justify-between px-5">
+        <div className="flex items-center gap-2.5">
+          {/* GitHub icon */}
+          <svg width="22" height="22" viewBox="0 0 16 16" fill="rgba(255,255,255,0.9)" aria-hidden="true">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+          </svg>
+          <span className="text-[15px] font-semibold text-[#e6edf3] tracking-tight">Diff Viewer</span>
+        </div>
         <TokenSettings />
       </header>
 
-      <main className="max-w-screen-xl mx-auto p-6 space-y-4">
-        <div className="grid grid-cols-2 gap-4">
+      <main className="max-w-screen-xl mx-auto p-5 space-y-4">
+        <div className="grid grid-cols-[1fr_auto_1fr] gap-3 items-start">
           <FileSelector
             side="left"
             value={localState.left}
             onChange={(value) => setLocalState((s) => ({ ...s, left: value }))}
           />
+          <div className="pt-9 text-[#636c76]">
+            {/* Right arrow icon */}
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M8.22 2.97a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l2.97-2.97H3.75a.75.75 0 0 1 0-1.5h7.44L8.22 4.03a.75.75 0 0 1 0-1.06z" />
+            </svg>
+          </div>
           <FileSelector
             side="right"
             value={localState.right}
@@ -55,22 +70,62 @@ function ComparePageContent() {
           />
         </div>
 
-        <div className="flex justify-center">
-          <button
-            type="button"
-            onClick={handleCompare}
-            disabled={!canCompare}
-            className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
-          >
-            {isLoading ? "取得中..." : "比較する"}
-          </button>
+        {/* Action Bar */}
+        <div className="bg-white border border-[#d0d7de] rounded-md flex items-center justify-between px-4 py-2.5">
+          <div className="flex items-center gap-2">
+            {hasContent && (
+              <>
+                <span className="w-2 h-2 rounded-full bg-[#3fb950]" />
+                <span className="text-sm text-[#636c76]">
+                  差分を表示中 —{" "}
+                  <strong className="text-[#1f2328]">{fileName}</strong>
+                </span>
+              </>
+            )}
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex rounded-md border border-[#d0d7de] overflow-hidden text-sm">
+              <button
+                type="button"
+                onClick={() => setMode("split")}
+                disabled={!hasContent}
+                className={`px-3.5 py-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+                  mode === "split"
+                    ? "bg-[#0969da] text-white"
+                    : "bg-white text-[#1f2328] hover:bg-[#f6f8fa]"
+                }`}
+              >
+                Split
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("unified")}
+                disabled={!hasContent}
+                className={`px-3.5 py-1 border-l border-[#d0d7de] disabled:opacity-50 disabled:cursor-not-allowed transition-colors ${
+                  mode === "unified"
+                    ? "bg-[#0969da] text-white"
+                    : "bg-white text-[#1f2328] hover:bg-[#f6f8fa]"
+                }`}
+              >
+                Unified
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={handleCompare}
+              disabled={!canCompare}
+              className="px-4 py-1.5 bg-[#0969da] text-white rounded-md text-sm font-semibold hover:bg-[#0860ca] disabled:opacity-50 disabled:cursor-not-allowed border border-black/10 transition-colors"
+            >
+              {isLoading ? "取得中..." : "比較する"}
+            </button>
+          </div>
         </div>
 
         {(leftFile.error || rightFile.error) && (
           <div className="grid grid-cols-2 gap-4">
             <div>
               {leftFile.error && (
-                <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+                <div className="px-3 py-2 bg-[#ffebe9] border border-[#f5c6c6] rounded-md text-[#cf222e] text-sm">
                   <span className="font-semibold">Left: </span>
                   {leftFile.error}
                 </div>
@@ -78,7 +133,7 @@ function ComparePageContent() {
             </div>
             <div>
               {rightFile.error && (
-                <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+                <div className="px-3 py-2 bg-[#ffebe9] border border-[#f5c6c6] rounded-md text-[#cf222e] text-sm">
                   <span className="font-semibold">Right: </span>
                   {rightFile.error}
                 </div>
@@ -88,7 +143,12 @@ function ComparePageContent() {
         )}
 
         {hasContent && (
-          <DiffViewer leftContent={leftFile.content ?? ""} rightContent={rightFile.content ?? ""} />
+          <DiffViewer
+            leftContent={leftFile.content ?? ""}
+            rightContent={rightFile.content ?? ""}
+            splitView={mode === "split"}
+            fileName={fileName}
+          />
         )}
       </main>
     </div>
@@ -99,7 +159,7 @@ export default function ComparePage() {
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center min-h-screen text-gray-500">
+        <div className="flex items-center justify-center min-h-screen text-[#636c76]">
           読み込み中...
         </div>
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,11 @@ import { DiffViewer } from "@/components/DiffViewer";
 import { FileSelector } from "@/components/FileSelector";
 import { TokenSettings } from "@/components/TokenSettings";
 import { useFileContent } from "@/hooks/useFileContent";
+import type { FileSpec } from "@/hooks/useQueryParams";
 import { useQueryParams } from "@/hooks/useQueryParams";
+
+const isReady = (s: FileSpec) =>
+  s.owner.trim() !== "" && s.repo.trim() !== "" && s.ref.trim() !== "" && s.path.trim() !== "";
 
 function ComparePageContent() {
   const { state, update } = useQueryParams();
@@ -22,9 +26,6 @@ function ComparePageContent() {
 
   const isLoading = leftFile.loading || rightFile.loading;
   const hasContent = leftFile.content !== null && rightFile.content !== null;
-
-  const isReady = (s: typeof localState.left) =>
-    s.owner.trim() !== "" && s.repo.trim() !== "" && s.ref.trim() !== "" && s.path.trim() !== "";
   const canCompare = !isLoading && isReady(localState.left) && isReady(localState.right);
 
   const leftName = displayedPaths?.left.split("/").pop() ?? "";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,11 @@ function ComparePageContent() {
   const { state, update } = useQueryParams();
   const [localState, setLocalState] = useState(state);
   const [mode, setMode] = useState<"split" | "unified">("split");
+  const [displayedPaths, setDisplayedPaths] = useState<{ left: string; right: string } | null>(
+    isReady(state.left) && isReady(state.right)
+      ? { left: state.left.path, right: state.right.path }
+      : null,
+  );
   const leftFile = useFileContent();
   const rightFile = useFileContent();
   const initialFetchDone = useRef(false);
@@ -22,7 +27,9 @@ function ComparePageContent() {
     s.owner.trim() !== "" && s.repo.trim() !== "" && s.ref.trim() !== "" && s.path.trim() !== "";
   const canCompare = !isLoading && isReady(localState.left) && isReady(localState.right);
 
-  const fileName = localState.left.path.split("/").pop() ?? "";
+  const leftName = displayedPaths?.left.split("/").pop() ?? "";
+  const rightName = displayedPaths?.right.split("/").pop() ?? "";
+  const fileName = leftName === rightName ? leftName : `${leftName} / ${rightName}`;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally run once on mount
   useEffect(() => {
@@ -34,6 +41,7 @@ function ComparePageContent() {
 
   const handleCompare = async () => {
     update(localState);
+    setDisplayedPaths({ left: localState.left.path, right: localState.right.path });
     await Promise.all([leftFile.fetch(localState.left), rightFile.fetch(localState.right)]);
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,10 +42,18 @@ function ComparePageContent() {
       <header className="h-12 bg-[#24292f] flex items-center justify-between px-5">
         <div className="flex items-center gap-2.5">
           {/* GitHub icon */}
-          <svg width="22" height="22" viewBox="0 0 16 16" fill="rgba(255,255,255,0.9)" aria-hidden="true">
+          <svg
+            width="22"
+            height="22"
+            viewBox="0 0 16 16"
+            fill="rgba(255,255,255,0.9)"
+            aria-hidden="true"
+          >
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
           </svg>
-          <span className="text-[15px] font-semibold text-[#e6edf3] tracking-tight">Diff Viewer</span>
+          <span className="text-[15px] font-semibold text-[#e6edf3] tracking-tight">
+            Diff Viewer
+          </span>
         </div>
         <TokenSettings />
       </header>
@@ -77,8 +85,7 @@ function ComparePageContent() {
               <>
                 <span className="w-2 h-2 rounded-full bg-[#3fb950]" />
                 <span className="text-sm text-[#636c76]">
-                  差分を表示中 —{" "}
-                  <strong className="text-[#1f2328]">{fileName}</strong>
+                  差分を表示中 — <strong className="text-[#1f2328]">{fileName}</strong>
                 </span>
               </>
             )}

--- a/src/components/DiffViewer.test.tsx
+++ b/src/components/DiffViewer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { DiffViewer } from "@/components/DiffViewer";
 
 vi.mock("react-diff-viewer-continued", () => ({
@@ -15,23 +15,19 @@ describe("DiffViewer", () => {
     expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-split-view", "true");
   });
 
-  test("shows Split and Unified toggle buttons", () => {
-    render(<DiffViewer {...defaultProps} />);
-    expect(screen.getByRole("button", { name: "Split" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Unified" })).toBeInTheDocument();
+  test("renders in split mode when splitView=true", () => {
+    render(<DiffViewer {...defaultProps} splitView={true} />);
+    expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-split-view", "true");
   });
 
-  test("switches to unified mode when Unified button is clicked", () => {
-    render(<DiffViewer {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: "Unified" }));
+  test("renders in unified mode when splitView=false", () => {
+    render(<DiffViewer {...defaultProps} splitView={false} />);
     expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-split-view", "false");
   });
 
-  test("switches back to split mode when Split button is clicked", () => {
-    render(<DiffViewer {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: "Unified" }));
-    fireEvent.click(screen.getByRole("button", { name: "Split" }));
-    expect(screen.getByTestId("diff-viewer")).toHaveAttribute("data-split-view", "true");
+  test("shows file name bar when fileName is provided", () => {
+    render(<DiffViewer {...defaultProps} fileName="index.ts" />);
+    expect(screen.getByText("index.ts")).toBeInTheDocument();
   });
 
   test("passes leftContent and rightContent to diff viewer", () => {

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -1,44 +1,27 @@
 "use client";
 
-import { useState } from "react";
 import ReactDiffViewer from "react-diff-viewer-continued";
 
 interface DiffViewerProps {
   leftContent: string;
   rightContent: string;
+  splitView?: boolean;
+  fileName?: string;
 }
 
-type Mode = "split" | "unified";
-
-export function DiffViewer({ leftContent, rightContent }: DiffViewerProps) {
-  const [mode, setMode] = useState<Mode>("split");
-
+export function DiffViewer({ leftContent, rightContent, splitView = true, fileName }: DiffViewerProps) {
   return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-2 bg-gray-50 border-b border-gray-200">
-        <span className="text-sm text-gray-600">差分</span>
-        <div className="flex rounded-md overflow-hidden border border-gray-300 text-sm">
-          <button
-            type="button"
-            onClick={() => setMode("split")}
-            className={`px-3 py-1 ${mode === "split" ? "bg-blue-600 text-white" : "bg-white text-gray-700 hover:bg-gray-50"}`}
-          >
-            Split
-          </button>
-          <button
-            type="button"
-            onClick={() => setMode("unified")}
-            className={`px-3 py-1 border-l border-gray-300 ${mode === "unified" ? "bg-blue-600 text-white" : "bg-white text-gray-700 hover:bg-gray-50"}`}
-          >
-            Unified
-          </button>
+    <div className="border border-[#d0d7de] rounded-md overflow-hidden">
+      {fileName && (
+        <div className="flex items-center gap-2 px-3 py-1.5 bg-[#f6f8fa] border-b border-[#d0d7de]">
+          <span className="font-mono text-xs text-[#1f2328]">{fileName}</span>
         </div>
-      </div>
+      )}
       <div className="overflow-auto text-sm">
         <ReactDiffViewer
           oldValue={leftContent}
           newValue={rightContent}
-          splitView={mode === "split"}
+          splitView={splitView}
         />
       </div>
     </div>

--- a/src/components/DiffViewer.tsx
+++ b/src/components/DiffViewer.tsx
@@ -9,7 +9,12 @@ interface DiffViewerProps {
   fileName?: string;
 }
 
-export function DiffViewer({ leftContent, rightContent, splitView = true, fileName }: DiffViewerProps) {
+export function DiffViewer({
+  leftContent,
+  rightContent,
+  splitView = true,
+  fileName,
+}: DiffViewerProps) {
   return (
     <div className="border border-[#d0d7de] rounded-md overflow-hidden">
       {fileName && (
@@ -18,11 +23,7 @@ export function DiffViewer({ leftContent, rightContent, splitView = true, fileNa
         </div>
       )}
       <div className="overflow-auto text-sm">
-        <ReactDiffViewer
-          oldValue={leftContent}
-          newValue={rightContent}
-          splitView={splitView}
-        />
+        <ReactDiffViewer oldValue={leftContent} newValue={rightContent} splitView={splitView} />
       </div>
     </div>
   );

--- a/src/components/FileSelector.test.tsx
+++ b/src/components/FileSelector.test.tsx
@@ -14,12 +14,12 @@ const ownerRepoPlaceholder = "owner/repository または GitHub URL";
 describe("FileSelector", () => {
   test("renders label for left side", () => {
     render(<FileSelector side="left" value={defaultValue} onChange={() => {}} />);
-    expect(screen.getByText("比較元（Left）")).toBeInTheDocument();
+    expect(screen.getByText("比較元 (Left)")).toBeInTheDocument();
   });
 
   test("renders label for right side", () => {
     render(<FileSelector side="right" value={defaultValue} onChange={() => {}} />);
-    expect(screen.getByText("比較先（Right）")).toBeInTheDocument();
+    expect(screen.getByText("比較先 (Right)")).toBeInTheDocument();
   });
 
   test("displays owner/repo combined in input", () => {

--- a/src/components/FileSelector.tsx
+++ b/src/components/FileSelector.tsx
@@ -12,7 +12,7 @@ interface FileSelectorProps {
 }
 
 const BADGE = {
-  left:  { bg: "bg-[#0550ae]", label: "L" },
+  left: { bg: "bg-[#0550ae]", label: "L" },
   right: { bg: "bg-[#1a7f37]", label: "R" },
 };
 const HEADER_LABEL = { left: "比較元 (Left)", right: "比較先 (Right)" };
@@ -125,14 +125,19 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
   return (
     <div className="bg-white border border-[#d0d7de] rounded-md overflow-hidden">
       <div className="px-3.5 py-2.5 border-b border-[#e8ebee] flex items-center gap-2">
-        <span className={`w-[22px] h-[22px] rounded flex items-center justify-center text-[11px] font-bold text-white ${badge.bg}`}>
+        <span
+          className={`w-[22px] h-[22px] rounded flex items-center justify-center text-[11px] font-bold text-white ${badge.bg}`}
+        >
           {badge.label}
         </span>
         <span className="text-sm font-semibold text-[#1f2328]">{HEADER_LABEL[side]}</span>
       </div>
       <div className="px-3.5 py-3 space-y-2.5">
         <div>
-          <label htmlFor={`${side}-owner-repo`} className="block text-xs font-medium text-[#636c76] mb-1">
+          <label
+            htmlFor={`${side}-owner-repo`}
+            className="block text-xs font-medium text-[#636c76] mb-1"
+          >
             Owner / Repository
           </label>
           <input

--- a/src/components/FileSelector.tsx
+++ b/src/components/FileSelector.tsx
@@ -11,7 +11,11 @@ interface FileSelectorProps {
   onChange: (value: FileSpec) => void;
 }
 
-const LABEL = { left: "比較元（Left）", right: "比較先（Right）" };
+const BADGE = {
+  left:  { bg: "bg-[#0550ae]", label: "L" },
+  right: { bg: "bg-[#1a7f37]", label: "R" },
+};
+const HEADER_LABEL = { left: "比較元 (Left)", right: "比較先 (Right)" };
 
 interface ParsedGitHubUrl {
   owner: string;
@@ -116,71 +120,80 @@ export function FileSelector({ side, value, onChange }: FileSelectorProps) {
     setFiles(result);
   };
 
+  const badge = BADGE[side];
+
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-3">
-      <h2 className="text-sm font-semibold text-gray-700">{LABEL[side]}</h2>
-      <div>
-        <label htmlFor={`${side}-owner-repo`} className="block text-xs text-gray-500 mb-1">
-          Owner / Repository
-        </label>
-        <input
-          id={`${side}-owner-repo`}
-          type="text"
-          value={ownerRepo}
-          placeholder="owner/repository または GitHub URL"
-          className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-          aria-invalid={!!urlError}
-          aria-describedby={urlError ? `${side}-url-error` : undefined}
-          onChange={(e) => handleOwnerRepoChange(e.target.value)}
-          onBlur={handleOwnerRepoBlur}
-        />
-        {urlError && (
-          <p id={`${side}-url-error`} role="alert" className="mt-1 text-xs text-red-600">
-            {urlError}
-          </p>
-        )}
+    <div className="bg-white border border-[#d0d7de] rounded-md overflow-hidden">
+      <div className="px-3.5 py-2.5 border-b border-[#e8ebee] flex items-center gap-2">
+        <span className={`w-[22px] h-[22px] rounded flex items-center justify-center text-[11px] font-bold text-white ${badge.bg}`}>
+          {badge.label}
+        </span>
+        <span className="text-sm font-semibold text-[#1f2328]">{HEADER_LABEL[side]}</span>
       </div>
-      <div>
-        <label htmlFor={`${side}-ref`} className="block text-xs text-gray-500 mb-1">
-          Ref（ブランチ / タグ / コミット）
-        </label>
-        <input
-          id={`${side}-ref`}
-          type="text"
-          value={value.ref}
-          placeholder="main"
-          list={`refs-${side}`}
-          className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-          onChange={(e) => update("ref", e.target.value)}
-          onBlur={handleRefBlur}
-        />
-        <datalist id={`refs-${side}`}>
-          {refs.branches.map((b) => (
-            <option key={`branch-${b}`} value={b} label={`branch: ${b}`} />
-          ))}
-          {refs.tags.map((t) => (
-            <option key={`tag-${t}`} value={t} label={`tag: ${t}`} />
-          ))}
-        </datalist>
-      </div>
-      <div>
-        <label htmlFor={`${side}-path`} className="block text-xs text-gray-500 mb-1">
-          File Path
-        </label>
-        <input
-          id={`${side}-path`}
-          type="text"
-          value={value.path}
-          placeholder="src/index.ts"
-          list={`files-${side}`}
-          className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-          onChange={(e) => update("path", e.target.value)}
-        />
-        <datalist id={`files-${side}`}>
-          {files.map((f) => (
-            <option key={f} value={f} />
-          ))}
-        </datalist>
+      <div className="px-3.5 py-3 space-y-2.5">
+        <div>
+          <label htmlFor={`${side}-owner-repo`} className="block text-xs font-medium text-[#636c76] mb-1">
+            Owner / Repository
+          </label>
+          <input
+            id={`${side}-owner-repo`}
+            type="text"
+            value={ownerRepo}
+            placeholder="owner/repository または GitHub URL"
+            className="w-full px-2.5 py-1.5 text-sm border border-[#d0d7de] rounded-md focus:outline-none focus:ring-2 focus:ring-[#0969da]/20 focus:border-[#0969da]"
+            aria-invalid={!!urlError}
+            aria-describedby={urlError ? `${side}-url-error` : undefined}
+            onChange={(e) => handleOwnerRepoChange(e.target.value)}
+            onBlur={handleOwnerRepoBlur}
+          />
+          {urlError && (
+            <p id={`${side}-url-error`} role="alert" className="mt-1 text-xs text-red-600">
+              {urlError}
+            </p>
+          )}
+        </div>
+        <div>
+          <label htmlFor={`${side}-ref`} className="block text-xs font-medium text-[#636c76] mb-1">
+            Ref（ブランチ / タグ / コミット）
+          </label>
+          <input
+            id={`${side}-ref`}
+            type="text"
+            value={value.ref}
+            placeholder="main"
+            list={`refs-${side}`}
+            className="w-full px-2.5 py-1.5 text-sm border border-[#d0d7de] rounded-md focus:outline-none focus:ring-2 focus:ring-[#0969da]/20 focus:border-[#0969da]"
+            onChange={(e) => update("ref", e.target.value)}
+            onBlur={handleRefBlur}
+          />
+          <datalist id={`refs-${side}`}>
+            {refs.branches.map((b) => (
+              <option key={`branch-${b}`} value={b} label={`branch: ${b}`} />
+            ))}
+            {refs.tags.map((t) => (
+              <option key={`tag-${t}`} value={t} label={`tag: ${t}`} />
+            ))}
+          </datalist>
+        </div>
+        <div>
+          <label htmlFor={`${side}-path`} className="block text-xs font-medium text-[#636c76] mb-1">
+            File Path
+          </label>
+          <input
+            id={`${side}-path`}
+            type="text"
+            value={value.path}
+            placeholder="src/index.ts"
+            list={`files-${side}`}
+            className="w-full px-2.5 py-1.5 text-sm border border-[#d0d7de] rounded-md focus:outline-none focus:ring-2 focus:ring-[#0969da]/20 focus:border-[#0969da]"
+            onChange={(e) => update("path", e.target.value)}
+          />
+          <datalist id={`files-${side}`}>
+            {files.map((f) => (
+              <option key={f} value={f} />
+            ))}
+          </datalist>
+        </div>
       </div>
     </div>
   );

--- a/src/components/TokenSettings.test.tsx
+++ b/src/components/TokenSettings.test.tsx
@@ -65,4 +65,20 @@ describe("TokenSettings", () => {
     expect(mockClearToken).toHaveBeenCalled();
     expect(screen.getByRole("button", { name: /PAT を設定/ })).toBeInTheDocument();
   });
+
+  test("closes modal when Escape key is pressed in input", () => {
+    render(<TokenSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /PAT を設定/ }));
+    const input = screen.getByPlaceholderText("GitHub Personal Access Token");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByPlaceholderText("GitHub Personal Access Token")).not.toBeInTheDocument();
+  });
+
+  test("closes modal when overlay is clicked", () => {
+    render(<TokenSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /PAT を設定/ }));
+    expect(screen.getByPlaceholderText("GitHub Personal Access Token")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "モーダルを閉じる" }));
+    expect(screen.queryByPlaceholderText("GitHub Personal Access Token")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/TokenSettings.test.tsx
+++ b/src/components/TokenSettings.test.tsx
@@ -14,55 +14,55 @@ describe("TokenSettings", () => {
     mockGetToken.mockReturnValue(null);
   });
 
-  test("shows 'トークンを設定' button when no token is set", () => {
+  test("shows 'PAT を設定' button when no token is set", () => {
     render(<TokenSettings />);
-    expect(screen.getByRole("button", { name: "トークンを設定" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /PAT を設定/ })).toBeInTheDocument();
   });
 
-  test("shows 'トークンをクリア' button when token is already set", () => {
+  test("shows 'PAT 設定済み' button when token is already set", () => {
     mockGetToken.mockReturnValue("ghp_existing");
     render(<TokenSettings />);
-    expect(screen.getByRole("button", { name: "トークンをクリア" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /PAT 設定済み/ })).toBeInTheDocument();
   });
 
-  test("shows input field after clicking 'トークンを設定'", () => {
+  test("shows input field after clicking 'PAT を設定'", () => {
     render(<TokenSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "トークンを設定" }));
+    fireEvent.click(screen.getByRole("button", { name: /PAT を設定/ }));
     expect(screen.getByPlaceholderText("GitHub Personal Access Token")).toBeInTheDocument();
   });
 
   test("saves token and hides input on save", () => {
     render(<TokenSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "トークンを設定" }));
+    fireEvent.click(screen.getByRole("button", { name: /PAT を設定/ }));
     const input = screen.getByPlaceholderText("GitHub Personal Access Token");
     fireEvent.change(input, { target: { value: "ghp_newtoken" } });
     fireEvent.click(screen.getByRole("button", { name: "保存" }));
     expect(mockSetToken).toHaveBeenCalledWith("ghp_newtoken");
     expect(screen.queryByPlaceholderText("GitHub Personal Access Token")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "トークンをクリア" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /PAT 設定済み/ })).toBeInTheDocument();
   });
 
   test("does not save when input is blank", () => {
     render(<TokenSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "トークンを設定" }));
+    fireEvent.click(screen.getByRole("button", { name: /PAT を設定/ }));
     fireEvent.click(screen.getByRole("button", { name: "保存" }));
     expect(mockSetToken).not.toHaveBeenCalled();
   });
 
   test("saves token on Enter key", () => {
     render(<TokenSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "トークンを設定" }));
+    fireEvent.click(screen.getByRole("button", { name: /PAT を設定/ }));
     const input = screen.getByPlaceholderText("GitHub Personal Access Token");
     fireEvent.change(input, { target: { value: "ghp_enter" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(mockSetToken).toHaveBeenCalledWith("ghp_enter");
   });
 
-  test("clears token when 'トークンをクリア' is clicked", () => {
+  test("clears token when 'PAT 設定済み' is clicked", () => {
     mockGetToken.mockReturnValue("ghp_existing");
     render(<TokenSettings />);
-    fireEvent.click(screen.getByRole("button", { name: "トークンをクリア" }));
+    fireEvent.click(screen.getByRole("button", { name: /PAT 設定済み/ }));
     expect(mockClearToken).toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "トークンを設定" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /PAT を設定/ })).toBeInTheDocument();
   });
 });

--- a/src/components/TokenSettings.tsx
+++ b/src/components/TokenSettings.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { clearToken, getToken, setToken } from "@/lib/storage";
 
 export function TokenSettings() {
   const [hasToken, setHasToken] = useState(false);
   const [input, setInput] = useState("");
   const [showModal, setShowModal] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (showModal) inputRef.current?.focus();
+  }, [showModal]);
 
   useEffect(() => {
     setHasToken(!!getToken());
@@ -84,10 +89,10 @@ export function TokenSettings() {
                 ）を使用してください。プライベートリポジトリへのアクセスに必要です。パブリックリポジトリのみの場合は不要です。
               </p>
               <input
+                ref={inputRef}
                 type="password"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                autoFocus
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleSave();
                   if (e.key === "Escape") setShowModal(false);

--- a/src/components/TokenSettings.tsx
+++ b/src/components/TokenSettings.tsx
@@ -6,7 +6,7 @@ import { clearToken, getToken, setToken } from "@/lib/storage";
 export function TokenSettings() {
   const [hasToken, setHasToken] = useState(false);
   const [input, setInput] = useState("");
-  const [open, setOpen] = useState(false);
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     setHasToken(!!getToken());
@@ -17,7 +17,7 @@ export function TokenSettings() {
     setToken(input.trim());
     setHasToken(true);
     setInput("");
-    setOpen(false);
+    setShowModal(false);
   };
 
   const handleClear = () => {
@@ -26,59 +26,79 @@ export function TokenSettings() {
   };
 
   return (
-    <div className="flex items-center gap-2">
-      {hasToken ? (
-        <button
-          type="button"
-          onClick={handleClear}
-          className="px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50"
-        >
-          トークンをクリア
-        </button>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50"
-        >
-          トークンを設定
-        </button>
-      )}
+    <>
+      <button
+        type="button"
+        onClick={() => (hasToken ? handleClear() : setShowModal(true))}
+        className="flex items-center gap-1.5 bg-white/[.08] border border-white/15 rounded-md text-sm px-3 py-1.5 hover:bg-white/[.12] transition-colors"
+        style={{ color: hasToken ? "#3fb950" : "#e6edf3" }}
+      >
+        {/* Key icon */}
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M6.5 0a6.5 6.5 0 0 1 5.25 10.354l3.45 3.449a.75.75 0 1 1-1.06 1.06l-3.45-3.449A6.5 6.5 0 1 1 6.5 0zm0 1.5a5 5 0 1 0 0 10 5 5 0 0 0 0-10z" />
+        </svg>
+        {hasToken ? "PAT 設定済み" : "PAT を設定"}
+      </button>
 
-      {open && !hasToken && (
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2">
-            <input
-              type="password"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder="GitHub Personal Access Token"
-              className="px-3 py-1.5 text-sm border border-gray-300 rounded-md w-72 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              onKeyDown={(e) => e.key === "Enter" && handleSave()}
-            />
-            <button
-              type="button"
-              onClick={handleSave}
-              className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
-            >
-              保存
-            </button>
+      {showModal && (
+        <div
+          className="fixed inset-0 bg-[#010409]/50 flex items-center justify-center z-50"
+          onClick={() => setShowModal(false)}
+          onKeyDown={(e) => e.key === "Escape" && setShowModal(false)}
+        >
+          <div
+            className="bg-white rounded-xl w-[440px] shadow-xl border border-[#d0d7de]"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <div className="px-4 pt-4 pb-0 flex justify-between items-center">
+              <span className="text-base font-semibold text-[#1f2328]">GitHub Personal Access Token</span>
+              <button
+                type="button"
+                onClick={() => setShowModal(false)}
+                className="text-[#636c76] hover:text-[#1f2328] transition-colors"
+                aria-label="閉じる"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                  <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06z" />
+                </svg>
+              </button>
+            </div>
+            <div className="p-4">
+              <p className="text-sm text-[#636c76] mb-3 leading-relaxed">
+                Classic PAT（スコープ:{" "}
+                <code className="bg-[#f6f8fa] border border-[#d0d7de] rounded px-1 text-xs">repo</code>
+                ）を使用してください。プライベートリポジトリへのアクセスに必要です。パブリックリポジトリのみの場合は不要です。
+              </p>
+              <input
+                type="password"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleSave()}
+                placeholder="GitHub Personal Access Token"
+                className="w-full px-3 py-2 border border-[#d0d7de] rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-[#0969da]/20 focus:border-[#0969da]"
+              />
+            </div>
+            <div className="px-4 pb-4 flex justify-end items-center gap-2">
+              <a
+                href="https://github.com/settings/tokens/new?scopes=repo"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-[#0969da] mr-auto"
+              >
+                トークンを発行する →
+              </a>
+              <button
+                type="button"
+                onClick={handleSave}
+                className="px-4 py-1.5 bg-[#0969da] text-white rounded-md text-sm font-semibold hover:bg-[#0860ca] border border-black/10 transition-colors"
+              >
+                保存
+              </button>
+            </div>
           </div>
-          <p className="text-xs text-gray-500">
-            Classic PAT（スコープ: <code className="bg-gray-100 px-1 rounded">repo</code>
-            ）を使用してください。
-            プライベートリポジトリへのアクセスに必要です。パブリックリポジトリのみの場合は不要です。
-            <a
-              href="https://github.com/settings/tokens/new?scopes=repo"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-1 text-blue-600 hover:underline"
-            >
-              トークンを発行する →
-            </a>
-          </p>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/src/components/TokenSettings.tsx
+++ b/src/components/TokenSettings.tsx
@@ -41,25 +41,31 @@ export function TokenSettings() {
       </button>
 
       {showModal && (
-        <div
-          className="fixed inset-0 bg-[#010409]/50 flex items-center justify-center z-50"
-          onClick={() => setShowModal(false)}
-          onKeyDown={(e) => e.key === "Escape" && setShowModal(false)}
-        >
-          <div
-            className="bg-white rounded-xl w-[440px] shadow-xl border border-[#d0d7de]"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <button
+            type="button"
+            className="absolute inset-0 bg-[#010409]/50 cursor-default"
+            onClick={() => setShowModal(false)}
+            aria-label="モーダルを閉じる"
+          />
+          <div className="relative bg-white rounded-xl w-[440px] shadow-xl border border-[#d0d7de]">
             <div className="px-4 pt-4 pb-0 flex justify-between items-center">
-              <span className="text-base font-semibold text-[#1f2328]">GitHub Personal Access Token</span>
+              <span className="text-base font-semibold text-[#1f2328]">
+                GitHub Personal Access Token
+              </span>
               <button
                 type="button"
                 onClick={() => setShowModal(false)}
                 className="text-[#636c76] hover:text-[#1f2328] transition-colors"
                 aria-label="閉じる"
               >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
                   <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06z" />
                 </svg>
               </button>
@@ -67,14 +73,19 @@ export function TokenSettings() {
             <div className="p-4">
               <p className="text-sm text-[#636c76] mb-3 leading-relaxed">
                 Classic PAT（スコープ:{" "}
-                <code className="bg-[#f6f8fa] border border-[#d0d7de] rounded px-1 text-xs">repo</code>
+                <code className="bg-[#f6f8fa] border border-[#d0d7de] rounded px-1 text-xs">
+                  repo
+                </code>
                 ）を使用してください。プライベートリポジトリへのアクセスに必要です。パブリックリポジトリのみの場合は不要です。
               </p>
               <input
                 type="password"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleSave()}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSave();
+                  if (e.key === "Escape") setShowModal(false);
+                }}
                 placeholder="GitHub Personal Access Token"
                 className="w-full px-3 py-2 border border-[#d0d7de] rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-[#0969da]/20 focus:border-[#0969da]"
               />

--- a/src/components/TokenSettings.tsx
+++ b/src/components/TokenSettings.tsx
@@ -44,7 +44,7 @@ export function TokenSettings() {
         <div className="fixed inset-0 flex items-center justify-center z-50">
           <button
             type="button"
-            className="absolute inset-0 bg-[#010409]/50 cursor-default"
+            className="absolute inset-0 bg-[#010409]/50 cursor-pointer"
             onClick={() => setShowModal(false)}
             aria-label="モーダルを閉じる"
           />

--- a/src/components/TokenSettings.tsx
+++ b/src/components/TokenSettings.tsx
@@ -48,9 +48,14 @@ export function TokenSettings() {
             onClick={() => setShowModal(false)}
             aria-label="モーダルを閉じる"
           />
-          <div className="relative bg-white rounded-xl w-[440px] shadow-xl border border-[#d0d7de]">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="pat-modal-title"
+            className="relative bg-white rounded-xl w-[440px] shadow-xl border border-[#d0d7de]"
+          >
             <div className="px-4 pt-4 pb-0 flex justify-between items-center">
-              <span className="text-base font-semibold text-[#1f2328]">
+              <span id="pat-modal-title" className="text-base font-semibold text-[#1f2328]">
                 GitHub Personal Access Token
               </span>
               <button
@@ -82,6 +87,7 @@ export function TokenSettings() {
                 type="password"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
+                autoFocus
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleSave();
                   if (e.key === "Escape") setShowModal(false);

--- a/src/components/TokenSettings.tsx
+++ b/src/components/TokenSettings.tsx
@@ -52,7 +52,7 @@ export function TokenSettings() {
             role="dialog"
             aria-modal="true"
             aria-labelledby="pat-modal-title"
-            className="relative bg-white rounded-xl w-[440px] shadow-xl border border-[#d0d7de]"
+            className="relative bg-white rounded-xl w-full max-w-[440px] mx-4 shadow-xl border border-[#d0d7de]"
           >
             <div className="px-4 pt-4 pb-0 flex justify-between items-center">
               <span id="pat-modal-title" className="text-base font-semibold text-[#1f2328]">


### PR DESCRIPTION
## Summary

- **Header**: `bg-[#24292f]` ダークヘッダー、GitHub SVG ロゴ＋「Diff Viewer」テキスト
- **FileSelector**: L（`#0550ae`）/ R（`#1a7f37`）バッジ付きカードレイアウトに変更
- **TokenSettings**: インライン展開 → `fixed` モーダルダイアログに変更（オーバーレイクリックで閉じる）
- **page.tsx**: `grid-cols-[1fr_auto_1fr]` グリッド、比較ボタン＋Split/Unified トグルを Action Bar として分離
- **DiffViewer**: `splitView` / `fileName` props 追加、ファイル名バー追加、内部モード管理を削除
- テストを新 UI 仕様に合わせて更新

## Test plan

- [x] `npm test` 60 tests 全件パス
- [x] 手動動作確認（ヘッダー・バッジ・モーダル・Action Bar・ファイル名バー）

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)