### PR TITLE
fix: add CSS type declaration for TypeScript 6.0 compatibility

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css" {}


### PR DESCRIPTION
## 原因

PR #37 で `typescript` が 5.9.3 → 6.0.3 にアップグレードされた結果、`src/app/layout.tsx` での `import "./globals.css"` がビルドエラーになっていました。

TypeScript 6.0 では、CSS などの非 JS ファイルへの side-effect import（`import "*.css"`）に対して型宣言が必要になりました。

```
Type error: Cannot find module or type declarations for side-effect import of './globals.css'.
```

## 対応

`src/globals.d.ts` を追加し、CSS モジュールの型宣言を定義しました。

```ts
declare module "*.css" {}
```

## 参照

- 失敗したデプロイ: https://github.com/ot-nemoto/github-diff-viewer/actions/runs/25348281800/job/74322105484

🤖 Generated with [Claude Code](https://claude.com/claude-code)