### PR TITLE
docs: update Next.js version to 16 in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 | 用途 | 技術 |
 |------|------|
-| フレームワーク | Next.js 15（App Router） |
+| フレームワーク | Next.js 16（App Router） |
 | 言語 | TypeScript |
 | スタイリング | Tailwind CSS |
 | Formatter / Linter | Biome |


### PR DESCRIPTION
## 変更内容

PR #36 で Next.js 15 → 16 にアップグレードされたため、`docs/architecture.md` の技術スタック表記を更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)