### PR TITLE
[T21] biome migrate --write を prepare スクリプトに追加する

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -18,7 +18,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "error"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.8",
   "private": true,
   "scripts": {
+    "prepare": "biome migrate --write",
     "dev": "next dev --turbopack",
     "build": "next build",
     "build:static": "BUILD_MODE=static next build",


### PR DESCRIPTION
## 概要

`@biomejs/biome` のバージョン更新時に `biome.json` のスキーマバージョンが自動で同期されるようにする。

## 変更内容

`package.json` の `scripts` に `"prepare": "biome migrate --write"` を追加。

`npm install` 実行時に自動で `biome migrate --write` が走り、`biome.json` の `$schema` が最新バージョンに同期される。`npm install --omit=dev`（本番デプロイ時）では `prepare` がスキップされるため、devDependencies がない環境でも安全に動作する。

## 背景

Dependabot が `@biomejs/biome` をバンプするたびに `biome.json` の `$schema` を手動修正する必要があり、CI 失敗が繰り返し発生していた（PR #36、#42）。

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)